### PR TITLE
fix: address multiple security vulnerabilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ BOT_SECRET="ボットシークレット"
 BOT_REDIRECT_URL="ボットのOauthようのリダイレクトURL"
 
 DATABASE_URL="postgresql://user:0000@distopia-db:5432/distopia"
+
+# 32文字以上のランダムな文字列。Discord OAuth2トークンの暗号化に使用
+ENCRYPTION_KEY="ここに32文字以上のランダムな文字列を設定してください"

--- a/src/application/core/src/AppState.ts
+++ b/src/application/core/src/AppState.ts
@@ -6,6 +6,7 @@ import type { GuildMemberAdd } from "repo-memory/GuildMemberAdd";
 import type { JWTKey } from "repo-memory/JWTKey";
 import type { GuildBumpLateLimit } from "repo-memory/latelimit/GuildBumpLateLimit";
 import type { MessageCreateLateLimit } from "repo-memory/latelimit/MessageCreateLateLimit";
+import type { UserBumpLateLimit } from "repo-memory/latelimit/UserBumpLateLimit";
 import type { MessageCreate } from "repo-memory/MessageCreate";
 import type { OAuth2Guilds } from "repo-memory/OAuth2Guilds";
 import type { UnJoinedGuild } from "repo-memory/UnJoinedGuild";
@@ -23,6 +24,7 @@ export type AppState = {
     latelimit: {
       messageCreate: MessageCreateLateLimit;
       bump: GuildBumpLateLimit;
+      userBump: UserBumpLateLimit;
     };
     friend: Friend;
     guildEdit: GuildEdit;

--- a/src/application/core/src/Guild.ts
+++ b/src/application/core/src/Guild.ts
@@ -92,16 +92,26 @@ export class Guild extends Base {
 
   public async bump(user: User, guild: GuildModel) {
     const twoHours = 2 * 60 * 60 * 1000;
+    const oneHour = 1 * 60 * 60 * 1000;
     const { database, memory } = this.state;
-    const latelimit = memory.latelimit.bump;
+    const guildLimit = memory.latelimit.bump;
+    const userLimit = memory.latelimit.userBump;
     const nowDate = new Date();
-    const limit = latelimit.get(guild.id);
 
-    if (limit && limit.getTime() > Date.now()) {
-      return new LateLimitError(limit);
+    // Check guild-level rate limit
+    const guildLimitEntry = guildLimit.get(guild.id);
+    if (guildLimitEntry && guildLimitEntry.getTime() > Date.now()) {
+      return new LateLimitError(guildLimitEntry);
     }
 
-    latelimit.set(guild.id, new Date(nowDate.getTime() + twoHours));
+    // Check user-level rate limit (prevent a single user from spam-bumping across guilds)
+    const userLimitEntry = userLimit.get(user.id);
+    if (userLimitEntry && userLimitEntry.getTime() > Date.now()) {
+      return new LateLimitError(userLimitEntry);
+    }
+
+    guildLimit.set(guild.id, new Date(nowDate.getTime() + twoHours));
+    userLimit.set(user.id, new Date(nowDate.getTime() + oneHour));
 
     await database.guild.update({
       guildId: guild.id,

--- a/src/application/core/src/Memory.ts
+++ b/src/application/core/src/Memory.ts
@@ -20,6 +20,7 @@ export class Memory extends Base {
       this.state.memory.voiceChannelMember,
       this.state.memory.latelimit.bump,
       this.state.memory.latelimit.messageCreate,
+      this.state.memory.latelimit.userBump,
     ];
 
     for (const mem of mems) {

--- a/src/domain/repository/memory/src/latelimit/UserBumpLateLimit.ts
+++ b/src/domain/repository/memory/src/latelimit/UserBumpLateLimit.ts
@@ -1,0 +1,4 @@
+import { LateLimitMapWithGC } from "./LateLimitMapWithGC";
+import type { LimitDate } from "./LimitDate";
+
+export class UserBumpLateLimit extends LateLimitMapWithGC<string, LimitDate> {}

--- a/src/infrastructure/database/src/DatabaseClient/UserDiscordTable.ts
+++ b/src/infrastructure/database/src/DatabaseClient/UserDiscordTable.ts
@@ -1,26 +1,54 @@
+import { decrypt, encrypt } from "../TokenEncryption";
 import type { UserDiscordUpsertInput } from "../types";
 import { Base } from "./Base";
 
+function encryptTokens(input: UserDiscordUpsertInput): UserDiscordUpsertInput {
+  return {
+    ...input,
+    accessToken: encrypt(input.accessToken),
+    refreshToken: encrypt(input.refreshToken),
+  };
+}
+
+function decryptTokens<T extends { accessToken: string; refreshToken: string }>(record: T): T {
+  try {
+    return {
+      ...record,
+      accessToken: decrypt(record.accessToken),
+      refreshToken: decrypt(record.refreshToken),
+    };
+  } catch {
+    // If decryption fails, return the original data (for backward compatibility
+    // with previously stored unencrypted tokens)
+    return record;
+  }
+}
+
 export class UserDiscordTable extends Base {
   public async find(userId: string) {
-    return await this.prisma.userDiscord.findUnique({ where: { userId } });
+    const record = await this.prisma.userDiscord.findUnique({ where: { userId } });
+    return record ? decryptTokens(record) : null;
   }
 
   public async findAll() {
-    return await this.prisma.userDiscord.findMany();
+    const records = await this.prisma.userDiscord.findMany();
+    return records.map(decryptTokens);
   }
 
   public async upsert(input: UserDiscordUpsertInput) {
-    return await this.prisma.userDiscord.upsert({
-      where: { userId: input.userId },
-      update: input,
-      create: input,
+    const encrypted = encryptTokens(input);
+    const record = await this.prisma.userDiscord.upsert({
+      where: { userId: encrypted.userId },
+      update: encrypted,
+      create: encrypted,
     });
+    return decryptTokens(record);
   }
 
   public async upsertAll(inputs: UserDiscordUpsertInput[]) {
-    return await this.prisma.$transaction(
-      inputs.map((value) =>
+    const encryptedInputs = inputs.map(encryptTokens);
+    const records = await this.prisma.$transaction(
+      encryptedInputs.map((value) =>
         this.prisma.userDiscord.upsert({
           where: { userId: value.userId },
           update: value,
@@ -28,6 +56,7 @@ export class UserDiscordTable extends Base {
         }),
       ),
     );
+    return records.map(decryptTokens);
   }
 
   public async delete(userId: string) {

--- a/src/infrastructure/database/src/TokenEncryption.ts
+++ b/src/infrastructure/database/src/TokenEncryption.ts
@@ -1,0 +1,72 @@
+import { randomBytes, createCipheriv, createDecipheriv, createHash } from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 16;
+
+let encryptionKey: Buffer | null = null;
+
+export function isEncryptionEnabled(): boolean {
+  return encryptionKey !== null;
+}
+
+export function setEncryptionKey(key: string): void {
+  encryptionKey = createHash("sha256").update(key).digest();
+}
+
+function getKey(): Buffer {
+  if (!encryptionKey) {
+    throw new Error("ENCRYPTION_KEY is not configured");
+  }
+  return encryptionKey;
+}
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM.
+ * Returns the encrypted data in format "iv:authTag:ciphertext" (hex-encoded),
+ * or the original plaintext prefixed with "unencrypted:" if no key is configured.
+ */
+export function encrypt(plaintext: string): string {
+  if (!encryptionKey) {
+    return `unencrypted:${plaintext}`;
+  }
+
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  let encrypted = cipher.update(plaintext, "utf8", "hex");
+  encrypted += cipher.final("hex");
+  const authTag = cipher.getAuthTag().toString("hex");
+
+  // Format: iv:authTag:encryptedData
+  return `${iv.toString("hex")}:${authTag}:${encrypted}`;
+}
+
+/**
+ * Decrypt a string that was encrypted with `encrypt()`.
+ * Also handles unencrypted data (backward compatibility).
+ */
+export function decrypt(encryptedData: string): string {
+  // Handle unencrypted fallback
+  if (encryptedData.startsWith("unencrypted:")) {
+    return encryptedData.slice("unencrypted:".length);
+  }
+
+  const key = getKey();
+  const parts = encryptedData.split(":");
+  if (parts.length !== 3) {
+    throw new Error("Invalid encrypted data format");
+  }
+
+  const iv = Buffer.from(parts[0], "hex");
+  const authTag = Buffer.from(parts[1], "hex");
+  const encrypted = parts[2];
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(encrypted, "hex", "utf8");
+  decrypted += decipher.final("utf8");
+
+  return decrypted;
+}

--- a/src/infrastructure/database/src/index.ts
+++ b/src/infrastructure/database/src/index.ts
@@ -2,6 +2,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 
 import { DatabaseClient } from "./DatabaseClient";
 import { PrismaClient } from "./prisma-client/client";
+import { setEncryptionKey } from "./TokenEncryption";
 
 function genPrismaClient(databaseUrl: string) {
   return new PrismaClient({
@@ -11,6 +12,11 @@ function genPrismaClient(databaseUrl: string) {
   });
 }
 
-export function genDatabaseClient(databaseUrl: string) {
+export function genDatabaseClient(databaseUrl: string, encryptionKey?: string) {
+  if (encryptionKey) {
+    setEncryptionKey(encryptionKey);
+  }
   return new DatabaseClient(genPrismaClient(databaseUrl));
 }
+
+export { encrypt, decrypt } from "./TokenEncryption";

--- a/src/presentation/bot/src/EventHandler/InteractionCreateHandler/ChatInputCommand/FriendCommand.ts
+++ b/src/presentation/bot/src/EventHandler/InteractionCreateHandler/ChatInputCommand/FriendCommand.ts
@@ -10,6 +10,7 @@ import {
   type ChatInputCommandInteraction,
   type InteractionReplyOptions,
   type MessagePayload,
+  type PermissionResolvable,
   type RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from "discord.js";
 
@@ -19,6 +20,7 @@ import { ModalSended } from "../Base/Modal/ModalSended";
 type Options = {};
 
 export class FriendCommand extends ChatInputCommandBase<Options> {
+  public override requireUserGuildPermissions: PermissionResolvable[] = ["Administrator"];
   public override register: RESTPostAPIChatInputApplicationCommandsJSONBody = {
     name: "friend",
     description: "フレンド募集用のコマンドです。",

--- a/src/presentation/bot/src/EventHandler/InteractionCreateHandler/Modal/ReviewModal.ts
+++ b/src/presentation/bot/src/EventHandler/InteractionCreateHandler/Modal/ReviewModal.ts
@@ -35,7 +35,7 @@ export class ReviewModal extends ModalSubmitInteractionBase<Options> {
   ): Promise<InteractionReplyOptions | InteractionResponse<boolean>> {
     const { star, content } = options;
 
-    if (isNaN(star) || star > 5) {
+    if (isNaN(star) || star < 1 || star > 5) {
       return {
         content: `${star}は無効な値です。`,
         flags: [MessageFlags.Ephemeral],

--- a/src/presentation/web/src/lib/components/Header.svelte
+++ b/src/presentation/web/src/lib/components/Header.svelte
@@ -3,7 +3,6 @@
   import { resolve } from "$app/paths";
   import type { ResolvedPathname } from "$app/types";
   import DiscordIcon from "$lib/assets/icon/discord.webp";
-  import { PUBLIC_OAUTH_URL } from "$lib/shared/constant";
   import type { UserAuth } from "$lib/shared/types/UserAuth";
   import "@fontsource/inter/900.css";
   import "@fontsource/open-sans/800-italic.css";
@@ -77,7 +76,7 @@
     <div>
       {#if userData === null}
         <div class="discord-login">
-          <a href={PUBLIC_OAUTH_URL} rel="external">
+          <a href={resolve("/auth")}>
             <div class="login-block">
               <p class="discord-login-content inline">Login</p>
             </div>

--- a/src/presentation/web/src/lib/server/JWTClient.ts
+++ b/src/presentation/web/src/lib/server/JWTClient.ts
@@ -20,7 +20,7 @@ export type VerifyResult = {
   newToken?: string;
 };
 
-const fourteenDays = 14 * 24 * 60 * 60;
+const fourteenDaysMs = 14 * 24 * 60 * 60 * 1000;
 
 export class JWTClient {
   constructor() {
@@ -59,8 +59,8 @@ export class JWTClient {
         return { payload: null };
       }
       if (typeof unVerifiedPayload !== "string" && typeof unVerifiedPayload?.exp === "number") {
-        const exp = unVerifiedPayload.exp;
-        if (exp > Date.now() - fourteenDays) {
+        const expMs = unVerifiedPayload.exp * 1000; // exp is in seconds, convert to ms
+        if (expMs < Date.now() + fourteenDaysMs) {
           nearExp = true;
         }
       }

--- a/src/presentation/web/src/lib/server/auth.ts
+++ b/src/presentation/web/src/lib/server/auth.ts
@@ -1,9 +1,11 @@
+import { PUBLIC_BOT_ID, PUBLIC_URL } from "$env/static/public";
 import type { UserAuth } from "$lib/shared/types/UserAuth";
 import { core } from "./core";
 import { jwt } from "./jwt";
-import type { Cookies } from "@sveltejs/kit";
+import { redirect, type Cookies, type RequestEvent } from "@sveltejs/kit";
 
 const twoMonth = 2 * 30 * 24 * 60 * 60 * 1000;
+const stateCookieMaxAge = 10 * 60; // 10 minutes in seconds
 
 export async function verifyToken(
   cookies: Cookies,
@@ -45,4 +47,46 @@ export async function setToken(cookies: Cookies, token: string) {
 
 export async function deleteToken(cookies: Cookies) {
   cookies.delete("authorization", { path: "/" });
+}
+
+function generateState(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function setOAuthStateCookie(cookies: Cookies): string {
+  const state = generateState();
+  cookies.set("oauth_state", state, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: true,
+    maxAge: stateCookieMaxAge,
+  });
+  return state;
+}
+
+export function getAndVerifyOAuthState(cookies: Cookies, stateFromQuery: string | null): boolean {
+  if (!stateFromQuery) {
+    return false;
+  }
+  const storedState = cookies.get("oauth_state");
+  if (!storedState) {
+    return false;
+  }
+  // Consume the state cookie immediately to prevent replay
+  cookies.delete("oauth_state", { path: "/" });
+  return storedState === stateFromQuery;
+}
+
+export function redirectToDiscordOAuth(cookies: Cookies): never {
+  const state = setOAuthStateCookie(cookies);
+  const oauthUrl = new URL("https://discord.com/oauth2/authorize");
+  oauthUrl.searchParams.set("client_id", PUBLIC_BOT_ID);
+  oauthUrl.searchParams.set("response_type", "code");
+  oauthUrl.searchParams.set("redirect_uri", `${PUBLIC_URL}/auth`);
+  oauthUrl.searchParams.set("scope", "identify guilds email guilds.join");
+  oauthUrl.searchParams.set("state", state);
+  throw redirect(302, oauthUrl.toString());
 }

--- a/src/presentation/web/src/lib/server/database.ts
+++ b/src/presentation/web/src/lib/server/database.ts
@@ -1,4 +1,7 @@
 import { DATABASE_URL } from "$env/static/private";
+import { env } from "$env/dynamic/private";
 import { genDatabaseClient } from "infra-database";
 
-export const database = genDatabaseClient(DATABASE_URL);
+const encryptionKey: string | undefined = env.ENCRYPTION_KEY;
+
+export const database = genDatabaseClient(DATABASE_URL, encryptionKey);

--- a/src/presentation/web/src/lib/server/memory.ts
+++ b/src/presentation/web/src/lib/server/memory.ts
@@ -11,11 +11,13 @@ import { UserOAuth2 } from "repo-memory/UserOAuth2";
 import { VoiceChannelMember } from "repo-memory/VoiceChannelMember";
 import { GuildBumpLateLimit } from "repo-memory/latelimit/GuildBumpLateLimit";
 import { MessageCreateLateLimit } from "repo-memory/latelimit/MessageCreateLateLimit";
+import { UserBumpLateLimit } from "repo-memory/latelimit/UserBumpLateLimit";
 
 export const memory: AppState["memory"] = {
   latelimit: {
     messageCreate: new MessageCreateLateLimit(),
     bump: new GuildBumpLateLimit(),
+    userBump: new UserBumpLateLimit(),
   },
   friend: new Friend(),
   guildEdit: new GuildEdit(),

--- a/src/presentation/web/src/lib/shared/constant.ts
+++ b/src/presentation/web/src/lib/shared/constant.ts
@@ -86,6 +86,4 @@ export const supporters = [
   },
 ] satisfies Supporter[];
 
-export const PUBLIC_OAUTH_URL = `https://discord.com/oauth2/authorize?client_id=${PUBLIC_BOT_ID}&response_type=code&redirect_uri=${encodeURIComponent(`${PUBLIC_URL}/auth`)}&scope=identify+guilds+email+guilds.join`;
-
 export const PUBLIC_BOT_INVITE_LINK = `https://discord.com/oauth2/authorize?client_id=${PUBLIC_BOT_ID}&permissions=8&integration_type=0&scope=bot`;

--- a/src/presentation/web/src/routes/auth/+page.server.ts
+++ b/src/presentation/web/src/routes/auth/+page.server.ts
@@ -1,4 +1,4 @@
-import { setToken } from "$lib/server/auth";
+import { getAndVerifyOAuthState, redirectToDiscordOAuth, setToken } from "$lib/server/auth";
 import { core } from "$lib/server/core";
 import { jwt } from "$lib/server/jwt";
 import type { UserAuth } from "$lib/shared/types/UserAuth";
@@ -6,9 +6,15 @@ import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (e) => {
   const code = e.url.searchParams.get("code");
+  const state = e.url.searchParams.get("state");
   let user: UserAuth | null = null;
 
   if (code) {
+    // Validate state parameter to prevent CSRF
+    if (!getAndVerifyOAuthState(e.cookies, state)) {
+      return { user: null, error: "Invalid OAuth state. Please try logging in again." };
+    }
+
     const apiResult = await core.oauth2.codeToUser(code);
 
     if (apiResult) {
@@ -24,6 +30,9 @@ export const load: PageServerLoad = async (e) => {
         };
       }
     }
+  } else {
+    // No code present — initiate OAuth flow with state parameter
+    redirectToDiscordOAuth(e.cookies);
   }
 
   return { user };

--- a/src/presentation/web/src/routes/auth/+page.svelte
+++ b/src/presentation/web/src/routes/auth/+page.svelte
@@ -5,11 +5,13 @@
   import { onMount } from "svelte";
 
   const { data } = $props();
-  const { user } = $derived(data);
-  const result = $derived(user ? "認証に成功しました。" : "認証に失敗しました。");
+  const { user, error } = $derived(data);
+  const result = $derived(
+    error ?? (user ? "認証に成功しました。" : "認証に失敗しました。"),
+  );
   const title = $derived(result);
   const description = $derived(
-    result ? `${result}数秒後にリダイレクトされます。` : `${result}再度試してみてください。`,
+    user ? `${result}数秒後にリダイレクトされます。` : `${result}再度試してみてください。`,
   );
 
   onMount(async () => {


### PR DESCRIPTION
## 脆弱性修正パッチ

### 🔴 Critical: OAuth2 CSRF対策（stateパラメータ追加）
**CWE-352**: Discord OAuth2フローにstateパラメータを追加し、アカウント連結CSRFを防止。
- OAuth認証URLにランダムなstateを生成して付加
- コールバック時にstateをCookieと照合して検証（使い捨て）
- ログインボタンを直接Discord URLではなく`/auth`エンドポイント経由に変更

### 🟠 High: JWT nearExp次元バグ修正
**CWE-682**: JWTの有効期限チェックで秒とミリ秒の単位が混在していたバグを修正。
- `fourteenDays` を秒→ミリ秒に変更
- `exp`（秒）を `exp * 1000` でミリ秒に変換して比較

### 🟠 High: Discord OAuth2トークンの暗号化
**CWE-312**: データベースに保存するDiscordアクセストークン/リフレッシュトークンをAES-256-GCMで暗号化。
- 新規: `TokenEncryption.ts`（暗号化/復号ユーティリティ）
- `UserDiscordTable`で透過的に暗号化・復号
- `ENCRYPTION_KEY` 環境変数で鍵を設定（未設定時は平文フォールバック）

### 🟠 High: Bumpにユーザーレベルのレート制限追加
**CWE-799**: 従来のサーバー単位に加え、ユーザー単位のレート制限を追加（1時間クールダウン）。
- 新規: `UserBumpLateLimit.ts`
- 同一ユーザーが複数サーバーで連続Bumpする攻撃を防止

### 🟡 Medium: レビュースター値のバリデーション強化
**CWE-20**: スター値の下限チェック（`star < 1`）を追加。

### 🟡 Medium: Friendコマンドに権限チェック追加
**CWE-862**: `/friend` コマンドに `Administrator` 権限チェックを追加（Modalとの一貫性向上）。

---

**影響ファイル**: 16ファイル変更、2ファイル新規作成