### PR TITLE
Fix private guild listing exposure

### DIFF
--- a/src/application/core/src/Guild.ts
+++ b/src/application/core/src/Guild.ts
@@ -10,6 +10,7 @@ import type { SearchOptions } from "repo-search";
 
 import type { AppState } from "./AppState";
 import { Base } from "./Base";
+import type { Ranking } from "./Ranking";
 import type { Record } from "./Record";
 import type { GuildMetaData } from "./types/GuildMetaData";
 import type { RootPage } from "./types/RootPage";
@@ -23,8 +24,19 @@ export class Guild extends Base {
   constructor(
     state: AppState,
     private readonly record: Record,
+    private readonly ranking: Ranking,
   ) {
     super(state);
+  }
+
+  private async removeFromPublicCaches(guildId: string) {
+    this.rootPage.latestGuilds = this.rootPage.latestGuilds.filter(
+      ({ guild }) => guild.guildId !== guildId,
+    );
+    this.rootPage.activeGuilds = this.rootPage.activeGuilds.filter(
+      ({ guild }) => guild.guildId !== guildId,
+    );
+    await this.ranking.cleanCache();
   }
 
   public async updateRootPage() {
@@ -35,13 +47,15 @@ export class Guild extends Base {
   public async loadSearchEngine() {
     const guilds = await this.state.database.guild.findAll();
     await this.state.searchEngine.upsertAll(
-      guilds.map(({ guildId, name, description, nsfw, tags }) => ({
-        guildId,
-        name,
-        description: description ?? "",
-        nsfw,
-        tags,
-      })),
+      guilds
+        .filter((guild) => guild.public)
+        .map(({ guildId, name, description, nsfw, tags }) => ({
+          guildId,
+          name,
+          description: description ?? "",
+          nsfw,
+          tags,
+        })),
     );
   }
 
@@ -127,6 +141,13 @@ export class Guild extends Base {
   }
 
   public async save(input: GuildUpsertInput) {
+    if (input.public === false) {
+      const guild = await this.state.database.guild.upsert(input);
+      await this.state.searchEngine.delete(input.guildId);
+      await this.removeFromPublicCaches(input.guildId);
+      return guild;
+    }
+
     await this.state.searchEngine.upsert({
       guildId: input.guildId,
       name: input.name,

--- a/src/application/core/src/index.ts
+++ b/src/application/core/src/index.ts
@@ -17,7 +17,8 @@ import { VoiceChannel } from "./VoiceChannel";
 export class AppCore extends Base {
   public readonly record = new Record(this.state);
   public readonly activeRate = new ActiveRate(this.state);
-  public readonly guild = new Guild(this.state, this.record);
+  public readonly ranking = new Ranking(this.state);
+  public readonly guild = new Guild(this.state, this.record, this.ranking);
   public readonly jwt = new JWT(this.state);
   public readonly latelimit = new LateLimit(this.state);
   public readonly friend = new Friend(this.state);
@@ -26,7 +27,6 @@ export class AppCore extends Base {
   public readonly message = new Message(this.state);
   public readonly oauth2 = new OAuth2(this.state, this.guild);
   public readonly panel = new Panel(this.state);
-  public readonly ranking = new Ranking(this.state);
   public readonly user = new User(this.state, this.oauth2);
   public readonly voice = new VoiceChannel(this.state);
 

--- a/src/domain/repository/search/src/SearchEngine.test.ts
+++ b/src/domain/repository/search/src/SearchEngine.test.ts
@@ -18,4 +18,20 @@ describe("Search Engine", async () => {
 
     expect(result.count).toBe(1);
   });
+
+  test("delete", async () => {
+    await searchEngine.upsert({
+      guildId: "22222222222",
+      name: "削除するサーバー",
+      description: "temporary server",
+      nsfw: false,
+      tags: ["temporary"],
+    });
+
+    await searchEngine.delete("22222222222");
+
+    const result = await searchEngine.search("temporary");
+
+    expect(result.count).toBe(0);
+  });
 });

--- a/src/domain/repository/search/src/SearchEngine.ts
+++ b/src/domain/repository/search/src/SearchEngine.ts
@@ -43,7 +43,7 @@ export class SearchEngine {
     const dbId = this.guildIdToDbId.get(guildId);
     if (dbId) {
       await remove(this.guildDb, dbId);
-      this.guildIdToDbId.delete(dbId);
+      this.guildIdToDbId.delete(guildId);
     }
   }
 

--- a/src/infrastructure/database/prisma/sql/getRankingActiveRate.sql
+++ b/src/infrastructure/database/prisma/sql/getRankingActiveRate.sql
@@ -1,6 +1,6 @@
 SELECT *
 FROM "GuildRecord" as gr
     INNER JOIN "Guild" as g
-    ON gr."guildId" = g."guildId"
+    ON gr."guildId" = g."guildId" AND g."public" IS TRUE
 ORDER BY gr."activeRate" DESC
 LIMIT $1;

--- a/src/infrastructure/database/prisma/sql/getRankingLevel.sql
+++ b/src/infrastructure/database/prisma/sql/getRankingLevel.sql
@@ -1,6 +1,6 @@
 SELECT *
 FROM "GuildRecord" as gr
     INNER JOIN "Guild" as g
-    ON gr."guildId" = g."guildId"
+    ON gr."guildId" = g."guildId" AND g."public" IS TRUE
 ORDER BY gr."level" DESC
 LIMIT $1;

--- a/src/infrastructure/database/src/DatabaseClient/GuildTable.ts
+++ b/src/infrastructure/database/src/DatabaseClient/GuildTable.ts
@@ -44,6 +44,9 @@ export class GuildTable extends Base {
 
   public async findAllSortedBumpTime(take?: number) {
     return await this.prisma.guild.findMany({
+      where: {
+        public: true,
+      },
       orderBy: {
         bumpTime: "desc",
       },


### PR DESCRIPTION
Private guilds could still appear in some public listing paths. This filters them from latest/ranking/search index paths and clears public caches when a guild is hidden.