### PR TITLE
fix: reorder rate limiting logic in Guild class

### DIFF
--- a/src/application/core/src/Guild.ts
+++ b/src/application/core/src/Guild.ts
@@ -111,17 +111,17 @@ export class Guild extends Base {
     const nowDate = new Date();
     const limit = latelimit.get(guild.id);
 
-    if (limit && limit.getTime() > Date.now()) {
-      return new LateLimitError(limit);
-    }
-
-    latelimit.set(guild.id, new Date(nowDate.getTime() + twoHours));
-
     const dbGuildData = await this.state.database.guild.find(guild.id);
 
     if (!dbGuildData || !dbGuildData.public) {
       return null;
     }
+
+    if (limit && limit.getTime() > Date.now()) {
+      return new LateLimitError(limit);
+    }
+
+    latelimit.set(guild.id, new Date(nowDate.getTime() + twoHours));
 
     await database.guild.update({
       guildId: guild.id,

--- a/src/application/core/src/Guild.ts
+++ b/src/application/core/src/Guild.ts
@@ -109,13 +109,14 @@ export class Guild extends Base {
     const { database, memory } = this.state;
     const latelimit = memory.latelimit.bump;
     const nowDate = new Date();
-    const limit = latelimit.get(guild.id);
 
     const dbGuildData = await this.state.database.guild.find(guild.id);
 
     if (!dbGuildData || !dbGuildData.public) {
       return null;
     }
+
+    const limit = latelimit.get(guild.id);
 
     if (limit && limit.getTime() > Date.now()) {
       return new LateLimitError(limit);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bump behavior so the system now verifies a guild exists and is public before applying rate-limit checks. This prevents unnecessary errors and ensures users of non-public or missing guilds no longer encounter incorrect rate-limit responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->