### PR TITLE
fix: update publish command to use npx instead of sudo bunx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,4 +66,4 @@ jobs:
         run: |
           docker compose exec app sudo scripts/setup.sh
           docker compose exec app sudo bun run build
-          docker compose exec app sudo bash -c "cd lib/distopia && sudo bunx jsr publish ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}"
+          docker compose exec app sudo bash -c "cd lib/distopia && sudo npx jsr publish ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use an alternative package publishing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->