### PR TITLE
fix: adjust conditions for release pull request and add scanning secrets tools installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Release
 
 on:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
   changesets:
     name: Changesets
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     permissions:
       pull-requests: write
       contents: write
@@ -39,7 +38,14 @@ jobs:
       - name: Install Deps
         run: bun ci
 
+      - name: Install scanning secrets tools
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+          git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
+          PATH="${PATH}:/gitleaks"
+
       - name: Create Release Pull Request
+        if: github.event_name == 'push'
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the top-level release workflow.
  * Moved the release gating condition from the job level to the specific release-creation step.
  * Added a pre-release step that installs and prepares secret-scanning tools and updates PATH before creating the release pull request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->