### PR TITLE
fix: update gitleaks installation path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
           git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
           sudo mv gitleaks /usr/local/bin
-          sudo rm -rf gitleaks
+          git rm -r --cached gitleaks
 
       - name: Check tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Install scanning secrets tools
         run: |
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-          git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
+          git clone https://github.com/gitleaks/gitleaks.git "$RUNNER_TEMP/gitleaks"
+          cd "$RUNNER_TEMP/gitleaks" && make build
           sudo mv gitleaks /usr/local/bin
-          git rm -r --cached gitleaks
 
       - name: Check tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Install scanning secrets tools
         run: |
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-          cd ${{ runner.temp }} && git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
-          sudo install -m 0755 ${{ runner.temp }}/gitleaks /usr/local/bin
+          git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
+          sudo mv gitleaks /usr/local/bin
+          sudo rm -rf gitleaks
 
       - name: Check tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install scanning secrets tools
         run: |
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-          git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
-          sudo mv gitleaks /usr/local/bin
+          cd / && git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
+          sudo mv /gitleaks /usr/local/bin
 
       - name: Check tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install scanning secrets tools
         run: |
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-          cd /root && git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
-          sudo mv /root/gitleaks /usr/local/bin
+          cd ${{ runner.temp }} && git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
+          sudo mv ${{ runner.temp }}/gitleaks /usr/local/bin
 
       - name: Check tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install scanning secrets tools
         run: |
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-          cd / && git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
-          sudo mv /gitleaks /usr/local/bin
+          cd /root && git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
+          sudo mv /root/gitleaks /usr/local/bin
 
       - name: Check tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
           cd ${{ runner.temp }} && git clone https://github.com/gitleaks/gitleaks.git && cd gitleaks && make build
-          sudo mv ${{ runner.temp }}/gitleaks /usr/local/bin
+          sudo install -m 0755 ${{ runner.temp }}/gitleaks /usr/local/bin
 
       - name: Check tools
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release CI workflow to add cleanup of temporary installation artifacts for one of the secret-scanning tools, ensuring the scanner is reliably available during release jobs while keeping runners cleaner; the other scanner installation remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->