### PR TITLE
fix: correct JWT expiration check to account for milliseconds

### DIFF
--- a/src/presentation/web/src/lib/server/JWTClient.ts
+++ b/src/presentation/web/src/lib/server/JWTClient.ts
@@ -20,7 +20,7 @@ export type VerifyResult = {
   newToken?: string;
 };
 
-const fourteenDays = 14 * 24 * 60 * 60;
+const fourteenDays = 14 * 24 * 60 * 60 * 1000;
 
 export class JWTClient {
   constructor() {
@@ -60,7 +60,7 @@ export class JWTClient {
       }
       if (typeof unVerifiedPayload !== "string" && typeof unVerifiedPayload?.exp === "number") {
         const exp = unVerifiedPayload.exp;
-        if (exp > Date.now() - fourteenDays) {
+        if (exp * 1000 > Date.now() - fourteenDays) {
           nearExp = true;
         }
       }

--- a/src/presentation/web/src/lib/server/JWTClient.ts
+++ b/src/presentation/web/src/lib/server/JWTClient.ts
@@ -60,7 +60,8 @@ export class JWTClient {
       }
       if (typeof unVerifiedPayload !== "string" && typeof unVerifiedPayload?.exp === "number") {
         const exp = unVerifiedPayload.exp;
-        if (exp * 1000 > Date.now() - fourteenDays) {
+        const expMs = exp * 1000;
+        if (expMs > Date.now() - fourteenDays) {
           nearExp = true;
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JWT token expiration detection to use consistent time units, ensuring tokens are properly validated during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->